### PR TITLE
[deploy] add dockerfile and build script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1.73-bullseye  AS chef
+WORKDIR sui
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+RUN apt-get update && apt-get install -y cmake clang
+
+# Build and cache all dependencies.
+FROM chef AS builder 
+WORKDIR /
+COPY Cargo.toml ./
+COPY src ./src
+RUN cargo build --release 
+
+# Production Image
+FROM debian:bullseye-slim AS runtime
+COPY --from=builder /target/release/sui-gas-station /usr/local/bin
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION
+

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# fast fail.
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCKERFILE="$DIR/Dockerfile"
+GIT_REVISION="$(git describe --always --dirty --exclude '*')"
+BUILD_DATE="$(date -u +'%Y-%m-%d')"
+
+echo
+echo "Building sui-gas-station docker image"
+echo "Dockerfile: \t$DOCKERFILE"
+echo "docker context: $REPO_ROOT"
+echo "build date: \t$BUILD_DATE"
+echo "git revision: \t$GIT_REVISION"
+echo
+
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+	--build-arg GIT_REVISION="$GIT_REVISION" \
+	--build-arg BUILD_DATE="$BUILD_DATE" \
+	"$@"


### PR DESCRIPTION
Get a start here by adding build configuration

test plan:

```
» ./docker/build.sh 

Building sui-gas-station docker image
Dockerfile:     /Users/jkjensen/mysten/sui-gas-station/docker/Dockerfile                                                     
docker context: /Users/jkjensen/mysten/sui-gas-station
build date:     2023-12-07                                    
git revision:   72235c1                                       

[+] Building 483.4s (16/16) FINISHED                          
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 74B                                                                                                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                                                                                              1.4s
 => [internal] load metadata for docker.io/library/rust:1.73-bullseye                                                                                                                                                                                1.4s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                                                                                                        0.0s
 => [auth] library/rust:pull token for registry-1.docker.io                                                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                                    0.0s
 => => transferring context: 1.47kB                                                                                                                                                                                                                  0.0s
 => [chef 1/3] FROM docker.io/library/rust:1.73-bullseye@sha256:fbc99ade5c476a8d602192a1bf8d50ae3361469c160d55a34379905ad4f82ae5                                                                                                                     0.0s
 => [runtime 1/2] FROM docker.io/library/debian:bullseye-slim@sha256:5aab272aa24713622bfac9dba239bc7488d9979b0d82d19a9dffccd99292154d                                                                                                                0.0s
 => CACHED [chef 2/3] WORKDIR sui                                                                                                                                                                                                                    0.0s
 => [chef 3/3] RUN apt-get update && apt-get install -y cmake clang                                                                                                                                                                                  9.6s
 => [builder 1/4] COPY Cargo.toml ./                                                                                                                                                                                                                 0.0s 
 => [builder 2/4] COPY src ./src                                                                                                                                                                                                                     0.0s 
 => [builder 3/4] RUN cargo build --release                                                                                                                                                                                                        471.9s 
 => CACHED [runtime 2/2] COPY --from=builder /target/release/sui-gas-station /usr/local/bin                                                                                                                                                          0.0s 
 => exporting to image                                                                                                                                                                                                                               0.0s 
 => => exporting layers                                                                                                                                                                                                                              0.0s 
 => => writing image sha256:f8b3d4b0537ea15b961307ebd01d818f1a11e98feab6d391dcc7785e400185de  