### PR TITLE
Actively release init lock after finish init

### DIFF
--- a/src/gas_pool_initializer.rs
+++ b/src/gas_pool_initializer.rs
@@ -265,6 +265,7 @@ impl GasPoolInitializer {
                 "No coins with balance above {} found. Skipping new coin initialization",
                 balance_threshold
             );
+            storage.release_init_lock().await.unwrap();
             return;
         }
         let total_coin_count = Arc::new(AtomicUsize::new(coins.len()));
@@ -290,6 +291,7 @@ impl GasPoolInitializer {
         for chunk in result.chunks(5000) {
             storage.add_new_coins(chunk.to_vec()).await.unwrap();
         }
+        storage.release_init_lock().await.unwrap();
         info!(
             "New coin initialization took {:?}s",
             start.elapsed().as_secs()

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,7 +42,11 @@ pub trait Storage: Sync + Send {
     /// Acquire a lock to initialize the gas pool for the given sponsor address for a certain duration.
     /// Returns true if the lock is acquired, false otherwise.
     /// Once the lock is acquired, until it expires, no other caller can acquire the lock.
+    /// The reason we use a lock duration is such that in case the server crashed while holding the lock,
+    /// the lock will be automatically considered as released after the lock duration.
     async fn acquire_init_lock(&self, lock_duration_sec: u64) -> anyhow::Result<bool>;
+
+    async fn release_init_lock(&self) -> anyhow::Result<()>;
 
     async fn check_health(&self) -> anyhow::Result<()>;
 

--- a/src/storage/redis/lua_scripts/release_init_lock.lua
+++ b/src/storage/redis/lua_scripts/release_init_lock.lua
@@ -1,0 +1,11 @@
+-- Copyright (c) Mysten Labs, Inc.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Release the lock for initializing a sponsor's account.
+-- This is done by setting the lock expiration time to 0.
+-- The first argument is the sponsor's address.
+
+local sponsor_address = ARGV[1]
+
+local t_init_lock = sponsor_address .. ':init_lock'
+redis.call('SET', t_init_lock, 0)

--- a/src/storage/redis/script_manager.rs
+++ b/src/storage/redis/script_manager.rs
@@ -11,6 +11,7 @@ const GET_IS_INITIALIZED_SCRIPT: &str = include_str!("lua_scripts/get_is_initial
 const GET_AVAILABLE_COIN_TOTAL_BALANCE_SCRIPT: &str =
     include_str!("lua_scripts/get_available_coin_total_balance.lua");
 const ACQUIRE_INIT_LOCK_SCRIPT: &str = include_str!("lua_scripts/acquire_init_lock.lua");
+const RELEASE_INIT_LOCK_SCRIPT: &str = include_str!("lua_scripts/release_init_lock.lua");
 
 #[cfg(test)]
 const GET_RESERVED_COIN_COUNT_SCRIPT: &str =
@@ -57,6 +58,11 @@ impl ScriptManager {
 
     pub fn acquire_init_lock_script() -> &'static Script {
         static SCRIPT: Lazy<Script> = Lazy::new(|| Script::new(ACQUIRE_INIT_LOCK_SCRIPT));
+        Lazy::force(&SCRIPT)
+    }
+
+    pub fn release_init_lock_script() -> &'static Script {
+        static SCRIPT: Lazy<Script> = Lazy::new(|| Script::new(RELEASE_INIT_LOCK_SCRIPT));
         Lazy::force(&SCRIPT)
     }
 


### PR DESCRIPTION
After finishing the coin init task, actively release the init lock instead of waiting for it to automatically expire. This is both more efficient, and also make it easier for tests to pass.