### PR TITLE
Support fullnode basic auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ repository = "https://github.com/MystenLabs/sui-gas-station"
 #typed-store = { path = "../sui-upstream/crates/typed-store" }
 #typed-store-derive = { path = "../sui-upstream/crates/typed-store-derive" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "ea66012b860d9dd152abb7f2156275698ee91126" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "mysten-metrics" }
-sui-config = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "sui-config" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "sui-json-rpc-types" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "sui-sdk" }
-sui-types = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "sui-types" }
-shared-crypto = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "shared-crypto" }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "telemetry-subscribers" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "878492bd2541dce1491791bcadf3cc855ddcdc05" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "mysten-metrics" }
+sui-config = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "sui-config" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "sui-json-rpc-types" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "sui-sdk" }
+sui-types = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "sui-types" }
+shared-crypto = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "shared-crypto" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "telemetry-subscribers" }
 
 anyhow = "1.0.75"
 async-trait = "0.1.51"
@@ -50,15 +50,15 @@ schemars = "0.8.16"
 tap = "1.0.1"
 tempfile = "3.2.0"
 tracing = "0.1.40"
-tokio = { version = "1.34.0", features = ["full"] }
+tokio = { version = "1.36.0", features = ["full"] }
 tokio-retry = "0.3.0"
 serde_json = "1.0.108"
 
 [dev-dependencies]
 rand = "0.8.5"
 
-sui-swarm-config = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "sui-swarm-config" }
-test-cluster = { git = "https://github.com/MystenLabs/sui", rev = "f6f7fb5717794de1e16bcf99a38ac4b1a3b6a409", package = "test-cluster" }
+sui-swarm-config = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "sui-swarm-config" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", rev = "03f05ddbc7ad27c3ae3640c792781987e7ff1b8f", package = "test-cluster" }
 
 [profile.release]
 panic = "abort"

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,10 @@ pub struct GasStationConfig {
     pub metrics_port: u16,
     pub gas_pool_config: GasPoolStorageConfig,
     pub fullnode_url: String,
+    /// An optional basic auth when connecting to the fullnode. If specified, the format is
+    /// (username, password).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fullnode_basic_auth: Option<(String, String)>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coin_init_config: Option<CoinInitConfig>,
     pub daily_gas_usage_cap: u64,
@@ -50,6 +54,7 @@ impl Default for GasStationConfig {
             metrics_port: DEFAULT_METRICS_PORT,
             gas_pool_config: GasPoolStorageConfig::default(),
             fullnode_url: "http://localhost:9000".to_string(),
+            fullnode_basic_auth: None,
             coin_init_config: Some(CoinInitConfig::default()),
             daily_gas_usage_cap: DEFAULT_DAILY_GAS_USAGE_CAP,
         }

--- a/src/gas_pool/gas_pool_core.rs
+++ b/src/gas_pool/gas_pool_core.rs
@@ -45,14 +45,14 @@ impl GasPool {
     pub async fn new(
         signer: Arc<dyn TxSigner>,
         gas_pool_store: Arc<dyn Storage>,
-        fullnode_url: &str,
+        sui_client: SuiClient,
         metrics: Arc<GasPoolCoreMetrics>,
         gas_usage_cap: Arc<GasUsageCap>,
     ) -> Arc<Self> {
         let pool = Self {
             signer,
             gas_pool_store,
-            sui_client: SuiClient::new(fullnode_url).await,
+            sui_client,
             metrics,
             gas_usage_cap,
         };
@@ -272,14 +272,14 @@ impl GasPoolContainer {
     pub async fn new(
         signer: Arc<dyn TxSigner>,
         gas_pool_store: Arc<dyn Storage>,
-        fullnode_url: &str,
+        sui_client: SuiClient,
         gas_usage_daily_cap: u64,
         metrics: Arc<GasPoolCoreMetrics>,
     ) -> Self {
         let inner = GasPool::new(
             signer,
             gas_pool_store,
-            fullnode_url,
+            sui_client,
             metrics,
             Arc::new(GasUsageCap::new(gas_usage_daily_cap)),
         )

--- a/src/sui_client.rs
+++ b/src/sui_client.rs
@@ -30,12 +30,12 @@ pub struct SuiClient {
 }
 
 impl SuiClient {
-    pub async fn new(fullnode_url: &str) -> Self {
-        let sui_client = SuiClientBuilder::default()
-            .max_concurrent_requests(100000)
-            .build(fullnode_url)
-            .await
-            .unwrap();
+    pub async fn new(fullnode_url: &str, basic_auth: Option<(String, String)>) -> Self {
+        let mut sui_client_builder = SuiClientBuilder::default().max_concurrent_requests(100000);
+        if let Some((username, password)) = basic_auth {
+            sui_client_builder = sui_client_builder.basic_auth(username, password);
+        }
+        let sui_client = sui_client_builder.build(fullnode_url).await.unwrap();
         Self { sui_client }
     }
 

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -7,6 +7,7 @@ use crate::gas_pool_initializer::GasPoolInitializer;
 use crate::metrics::{GasPoolCoreMetrics, GasPoolRpcMetrics};
 use crate::rpc::GasPoolServer;
 use crate::storage::connect_storage_for_testing;
+use crate::sui_client::SuiClient;
 use crate::tx_signer::{TestTxSigner, TxSigner};
 use crate::AUTH_ENV_NAME;
 use std::sync::Arc;
@@ -49,8 +50,9 @@ pub async fn start_gas_station(
     let sponsor_address = signer.get_address().await.unwrap();
     debug!("Starting storage. Sponsor address: {:?}", sponsor_address);
     let storage = connect_storage_for_testing(sponsor_address).await;
+    let sui_client = SuiClient::new(&fullnode_url, None).await;
     GasPoolInitializer::start(
-        fullnode_url.clone(),
+        sui_client.clone(),
         storage.clone(),
         CoinInitConfig {
             target_init_balance: target_init_coin_balance,
@@ -62,7 +64,7 @@ pub async fn start_gas_station(
     let station = GasPoolContainer::new(
         signer,
         storage,
-        fullnode_url.as_str(),
+        sui_client,
         DEFAULT_DAILY_GAS_USAGE_CAP,
         GasPoolCoreMetrics::new_for_testing(),
     )


### PR DESCRIPTION
If the fullnode is behind a proxy that requires basic authentication (i.e. username/password in the http header), we will need to provide the auth info in the sui client.
This PR adds the option to the config, where one can put in the config file the username and password.