### PR TITLE
Revert "Use better Histogram for metrics"

### DIFF
--- a/src/gas_pool/gas_pool_core.rs
+++ b/src/gas_pool/gas_pool_core.rs
@@ -72,7 +72,7 @@ impl GasPool {
             .await?;
         self.metrics
             .reserved_gas_coin_count_per_request
-            .observe(gas_coins.len() as f64);
+            .observe(gas_coins.len() as u64);
         Ok((
             sponsor,
             reservation_id,
@@ -190,7 +190,7 @@ impl GasPool {
         let elapsed = cur_time.elapsed().as_millis();
         self.metrics
             .transaction_execution_latency_ms
-            .observe(elapsed as f64);
+            .observe(elapsed as u64);
         let net_gas_usage = effects.gas_cost_summary().net_gas_usage();
         let new_daily_usage = self.gas_usage_cap.update_usage(net_gas_usage).await;
         self.metrics

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use mysten_metrics::histogram::Histogram;
 use prometheus::{
-    register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, register_int_gauge_vec_with_registry, Histogram,
-    IntCounter, IntCounterVec, IntGaugeVec, Registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_vec_with_registry, IntCounter, IntCounterVec, IntGaugeVec, Registry,
 };
 use std::sync::Arc;
 use tracing::error;
@@ -55,18 +55,16 @@ impl GasPoolRpcMetrics {
                 registry,
             )
             .unwrap(),
-            target_gas_budget_per_request: register_histogram_with_registry!(
+            target_gas_budget_per_request: Histogram::new_in_registry(
                 "target_gas_budget_per_request",
                 "Target gas budget value in the reserve_gas RPC request",
                 registry,
-            )
-            .unwrap(),
-            reserve_duration_per_request: register_histogram_with_registry!(
+            ),
+            reserve_duration_per_request: Histogram::new_in_registry(
                 "reserve_duration_per_request",
                 "Reserve duration value in the reserve_gas RPC request",
                 registry,
-            )
-            .unwrap(),
+            ),
             num_execute_tx_requests: register_int_counter_with_registry!(
                 "num_execute_tx_requests",
                 "Total number of execute_tx RPC requests received",
@@ -111,45 +109,43 @@ pub struct GasPoolCoreMetrics {
 impl GasPoolCoreMetrics {
     pub fn new(registry: &Registry) -> Arc<Self> {
         Arc::new(Self {
-            reserved_gas_coin_count_per_request: register_histogram_with_registry!(
+            reserved_gas_coin_count_per_request: Histogram::new_in_registry(
                 "reserved_gas_coin_count_per_request",
                 "Number of gas coins reserved in each reserve_gas RPC request",
                 registry,
-            )
-            .unwrap(),
+            ),
             num_expired_gas_coins: register_int_counter_vec_with_registry!(
                 "num_expired_gas_coins",
                 "Total number of gas coins that are put back due to reservation expiration",
                 &["sponsor"],
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             num_smashed_gas_coins: register_int_counter_vec_with_registry!(
                 "num_smashed_gas_coins",
                 "Total number of gas coins that are smashed (i.e. deleted) during transaction execution",
                 &["sponsor"],
                 registry,
             )
-            .unwrap(),
-            transaction_execution_latency_ms: register_histogram_with_registry!(
+                .unwrap(),
+            transaction_execution_latency_ms: Histogram::new_in_registry(
                 "transaction_execution_latency",
                 "Latency of transaction execution, in milliseconds",
                 registry,
-            )
-            .unwrap(),
+            ),
             num_gas_pool_invariant_violations: register_int_counter_with_registry!(
                 "num_gas_pool_invariant_violations",
                 "Total number of invariant violations in the gas pool core",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             daily_gas_usage: register_int_gauge_vec_with_registry!(
                 "daily_gas_usage",
                 "Current daily gas usage",
                 &["sponsor"],
                 registry,
             )
-            .unwrap()
+                .unwrap(),
         })
     }
 

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -150,11 +150,11 @@ async fn reserve_gas(
     server
         .metrics
         .target_gas_budget_per_request
-        .observe(gas_budget as f64);
+        .observe(gas_budget);
     server
         .metrics
         .reserve_duration_per_request
-        .observe(reserve_duration_secs as f64);
+        .observe(reserve_duration_secs);
     // Spawn a thread to process the request so that it will finish even when client drops the connection.
     tokio::task::spawn(reserve_gas_impl(
         server.gas_station.clone(),


### PR DESCRIPTION
This reverts commit 0bf4a915f0ba371e2a07fb22f3af3a25eae7c06a.
The issue with the default histogram is that it requires very accurate buckets.
Since we don't care about host aggregation that much in the case of gas pool, using mysten histogram is not that of a big concern I guess.