### PR TITLE
Cache signer address on init

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -51,9 +51,9 @@ impl Command {
         let _guard = telemetry_config.init();
         info!("Metrics server started at {:?}", metric_address);
 
-        let signer = signer_config.new_signer();
+        let signer = signer_config.new_signer().await;
         let storage_metrics = StorageMetrics::new(&prometheus_registry);
-        let sponsor_address = signer.get_address().await.unwrap();
+        let sponsor_address = signer.get_address();
         info!("Sponsor address: {:?}", sponsor_address);
         let storage = connect_storage(&gas_pool_config, sponsor_address, storage_metrics).await;
         let sui_client = SuiClient::new(&fullnode_url, fullnode_basic_auth).await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,10 +94,10 @@ impl Default for TxSignerConfig {
 }
 
 impl TxSignerConfig {
-    pub fn new_signer(self) -> Arc<dyn TxSigner> {
+    pub async fn new_signer(self) -> Arc<dyn TxSigner> {
         match self {
             TxSignerConfig::Local { keypair } => TestTxSigner::new(keypair),
-            TxSignerConfig::Sidecar { sidecar_url } => SidecarTxSigner::new(sidecar_url),
+            TxSignerConfig::Sidecar { sidecar_url } => SidecarTxSigner::new(sidecar_url).await,
         }
     }
 }

--- a/src/gas_pool/gas_pool_core.rs
+++ b/src/gas_pool/gas_pool_core.rs
@@ -65,7 +65,7 @@ impl GasPool {
         duration: Duration,
     ) -> anyhow::Result<(SuiAddress, ReservationID, Vec<ObjectRef>)> {
         self.gas_usage_cap.check_usage().await?;
-        let sponsor = self.signer.get_address().await?;
+        let sponsor = self.signer.get_address();
         let (reservation_id, gas_coins) = self
             .gas_pool_store
             .reserve_gas_coins(gas_budget, duration.as_millis() as u64)
@@ -87,7 +87,7 @@ impl GasPool {
         user_sig: GenericSignature,
     ) -> anyhow::Result<SuiTransactionBlockEffects> {
         let sponsor = tx_data.gas_data().owner;
-        if !self.signer.is_valid_address(&sponsor).await? {
+        if !self.signer.is_valid_address(&sponsor) {
             bail!("Sponsor {:?} is not registered", sponsor);
         };
         Self::check_transaction_validity(&tx_data)?;

--- a/src/gas_pool_initializer.rs
+++ b/src/gas_pool_initializer.rs
@@ -238,7 +238,7 @@ impl GasPoolInitializer {
         target_init_coin_balance: u64,
         signer: &Arc<dyn TxSigner>,
     ) {
-        let sponsor_address = signer.get_address().await.unwrap();
+        let sponsor_address = signer.get_address();
         if storage
             .acquire_init_lock(MAX_INIT_DURATION_SEC)
             .await
@@ -343,7 +343,7 @@ mod tests {
         telemetry_subscribers::init_for_testing();
         let (cluster, signer) = start_sui_cluster(vec![1000 * MIST_PER_SUI]).await;
         let fullnode_url = cluster.fullnode_handle.rpc_url;
-        let storage = connect_storage_for_testing(signer.get_address().await.unwrap()).await;
+        let storage = connect_storage_for_testing(signer.get_address()).await;
         let sui_client = SuiClient::new(&fullnode_url, None).await;
         let _ = GasPoolInitializer::start(
             sui_client,
@@ -363,7 +363,7 @@ mod tests {
         telemetry_subscribers::init_for_testing();
         let (cluster, signer) = start_sui_cluster(vec![10000000 * MIST_PER_SUI]).await;
         let fullnode_url = cluster.fullnode_handle.rpc_url;
-        let storage = connect_storage_for_testing(signer.get_address().await.unwrap()).await;
+        let storage = connect_storage_for_testing(signer.get_address()).await;
         let target_init_balance = 12345 * MIST_PER_SUI;
         let sui_client = SuiClient::new(&fullnode_url, None).await;
         let _ = GasPoolInitializer::start(
@@ -383,9 +383,9 @@ mod tests {
     async fn test_add_new_funds_to_pool() {
         telemetry_subscribers::init_for_testing();
         let (cluster, signer) = start_sui_cluster(vec![1000 * MIST_PER_SUI]).await;
-        let sponsor = signer.get_address().await.unwrap();
+        let sponsor = signer.get_address();
         let fullnode_url = cluster.fullnode_handle.rpc_url.clone();
-        let storage = connect_storage_for_testing(signer.get_address().await.unwrap()).await;
+        let storage = connect_storage_for_testing(signer.get_address()).await;
         let sui_client = SuiClient::new(&fullnode_url, None).await;
         let _init_task = GasPoolInitializer::start(
             sui_client,

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -47,7 +47,7 @@ pub async fn start_gas_station(
     debug!("Starting Sui cluster..");
     let (test_cluster, signer) = start_sui_cluster(init_gas_amounts).await;
     let fullnode_url = test_cluster.fullnode_handle.rpc_url.clone();
-    let sponsor_address = signer.get_address().await.unwrap();
+    let sponsor_address = signer.get_address();
     debug!("Starting storage. Sponsor address: {:?}", sponsor_address);
     let storage = connect_storage_for_testing(sponsor_address).await;
     let sui_client = SuiClient::new(&fullnode_url, None).await;


### PR DESCRIPTION
There is no need to keep querying KMS the address, we can cache it after the first query. It won't change.
The main change is in src/tx_signer.rs