### PR TITLE
Fix test failure

### DIFF
--- a/src/gas_pool/gas_pool_core.rs
+++ b/src/gas_pool/gas_pool_core.rs
@@ -130,6 +130,7 @@ impl GasPool {
                 );
                 #[cfg(test)]
                 {
+                    self.sui_client.wait_for_object(new_gas_coin).await;
                     assert_eq!(
                         self.get_total_gas_coin_balance(payment).await,
                         new_balance as u64


### PR DESCRIPTION
In the test assert there was a read-after-write consistency issue.
This PR fixes it by waiting for the object to be available before querying balance.