### PR TITLE
Add a new feature that allows gas pool to work in faucet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,5 +205,6 @@ A description of these fields:
     has been added.
 - daily-gas-usage-cap: The total amount of gas usage allowed per day, as a safety cap.
 - advanced-faucet-mode: This enables the gas pool to be configured to work in a faucet mode, where the sender and the sponsor
-    are the same, and gas coins are allowed to be used in the transaction. Do not use this unless you know what you are doing
-    as there are risk around the gas pool being depleted!
+    are the same, and gas coins are allowed to be used in the transaction other than gas payment, i.e. the balance of the gas
+    coin can be transferred away in an arbitrary way. Do not use this unless you know what you are doing as there are risks
+    around the gas pool being depleted!

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ coin-init-config:
   target-init-balance: 100000000
   refresh-interval-sec: 86400
 daily-gas-usage-cap: 1500000000000
+advanced-faucet-mode: false
 ```
 
 If you want to use in-memory signer, you can remove `--with-sidecar-signer` from the command.
@@ -203,3 +204,6 @@ A description of these fields:
   - refresh-interval-sec: The interval to look at all gas coins owned by the sponsor again and see if some new funding
     has been added.
 - daily-gas-usage-cap: The total amount of gas usage allowed per day, as a safety cap.
+- advanced-faucet-mode: This enables the gas pool to be configured to work in a faucet mode, where the sender and the sponsor
+    are the same, and gas coins are allowed to be used in the transaction. Do not use this unless you know what you are doing
+    as there are risk around the gas pool being depleted!

--- a/src/command.rs
+++ b/src/command.rs
@@ -39,6 +39,7 @@ impl Command {
             metrics_port,
             coin_init_config,
             daily_gas_usage_cap,
+            advanced_faucet_mode,
         } = config;
 
         let metric_address = SocketAddr::new(IpAddr::V4(rpc_host_ip), metrics_port);
@@ -77,6 +78,7 @@ impl Command {
             sui_client,
             daily_gas_usage_cap,
             core_metrics,
+            advanced_faucet_mode,
         )
         .await;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,10 @@ pub struct GasStationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coin_init_config: Option<CoinInitConfig>,
     pub daily_gas_usage_cap: u64,
+    /// Enables the gas pool to work as a faucet, where the sender is the same as the sponsor.
+    /// Do not set to true unless you have a specific or niche use case and you understand the
+    /// risks associated with this mode.
+    pub advanced_faucet_mode: bool,
 }
 
 impl Config for GasStationConfig {}
@@ -57,6 +61,7 @@ impl Default for GasStationConfig {
             fullnode_basic_auth: None,
             coin_init_config: Some(CoinInitConfig::default()),
             daily_gas_usage_cap: DEFAULT_DAILY_GAS_USAGE_CAP,
+            advanced_faucet_mode: false,
         }
     }
 }

--- a/src/gas_pool/gas_pool_core.rs
+++ b/src/gas_pool/gas_pool_core.rs
@@ -11,7 +11,10 @@ use crate::{retry_forever, retry_with_max_attempts};
 use anyhow::bail;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI};
+use sui_json_rpc_types::{
+    BalanceChange, SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponse,
+};
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::gas_coin::MIST_PER_SUI;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
@@ -41,6 +44,7 @@ pub struct GasPool {
     metrics: Arc<GasPoolCoreMetrics>,
     gas_usage_cap: Arc<GasUsageCap>,
     object_lock_manager: Arc<ObjectLockManager>,
+    advanced_faucet_mode: bool,
 }
 
 impl GasPool {
@@ -50,6 +54,7 @@ impl GasPool {
         sui_client: SuiClient,
         metrics: Arc<GasPoolCoreMetrics>,
         gas_usage_cap: Arc<GasUsageCap>,
+        advanced_faucet_mode: bool,
     ) -> Arc<Self> {
         let object_lock_manager = Arc::new(ObjectLockManager::new(Arc::new(sui_client.clone())));
         let pool = Self {
@@ -59,6 +64,7 @@ impl GasPool {
             metrics,
             gas_usage_cap,
             object_lock_manager,
+            advanced_faucet_mode,
         };
         Arc::new(pool)
     }
@@ -97,7 +103,7 @@ impl GasPool {
         if !self.signer.is_valid_address(&sponsor) {
             bail!("Sponsor {:?} is not registered", sponsor);
         };
-        Self::check_transaction_validity(&tx_data)?;
+        self.check_transaction_validity(&tx_data)?;
         let payment: Vec<_> = tx_data
             .gas_data()
             .payment
@@ -123,30 +129,48 @@ impl GasPool {
             ?reservation_id,
             "Total gas coin balance prior to execution: {}", total_gas_coin_balance,
         );
+
         let response = self
             .execute_transaction_impl(reservation_id, tx_data, user_sig)
             .await;
         let updated_coins = match &response {
-            Ok(effects) => {
-                let new_gas_coin = effects.gas_object().reference.to_object_ref();
-                let new_balance =
-                    total_gas_coin_balance as i64 - effects.gas_cost_summary().net_gas_usage();
-                debug!(
-                    ?reservation_id,
-                    "New gas coin balance after execution: {}", new_balance,
-                );
-                #[cfg(test)]
-                {
-                    self.sui_client.wait_for_object(new_gas_coin).await;
-                    assert_eq!(
-                        self.get_total_gas_coin_balance(payment).await,
-                        new_balance as u64
+            Ok(tx_response) => {
+                if let Some(ref effects) = tx_response.effects {
+                    let new_gas_coin = effects.gas_object().reference.to_object_ref();
+                    let new_balance = total_gas_coin_balance as i64
+                        - self.net_usage(
+                            reservation_id,
+                            effects,
+                            tx_response.balance_changes.as_ref(),
+                        )?;
+                    debug!(
+                        ?reservation_id,
+                        "New gas coin balance after execution: {}", new_balance,
                     );
+                    #[cfg(test)]
+                    {
+                        self.sui_client.wait_for_object(new_gas_coin).await;
+                        assert_eq!(
+                            self.get_total_gas_coin_balance(payment).await,
+                            new_balance as u64
+                        );
+                    }
+                    vec![GasCoin {
+                        object_ref: new_gas_coin,
+                        balance: new_balance as u64,
+                    }]
+                } else {
+                    debug!(
+                        ?reservation_id,
+                        "Querying latest gas state since transaction failed"
+                    );
+                    self.sui_client
+                        .get_latest_gas_objects(payment)
+                        .await
+                        .into_values()
+                        .flatten()
+                        .collect()
                 }
-                vec![GasCoin {
-                    object_ref: new_gas_coin,
-                    balance: new_balance as u64,
-                }]
             }
             Err(_) => {
                 debug!(
@@ -178,7 +202,10 @@ impl GasPool {
         }
         info!(?reservation_id, "Transaction execution finished");
 
-        response
+        response.and_then(|r| {
+            r.effects
+                .ok_or_else(|| anyhow::anyhow!("Transaction execution failed: no effects returned"))
+        })
     }
 
     async fn execute_transaction_impl(
@@ -186,7 +213,7 @@ impl GasPool {
         reservation_id: ReservationID,
         tx_data: TransactionData,
         user_sig: GenericSignature,
-    ) -> anyhow::Result<SuiTransactionBlockEffects> {
+    ) -> anyhow::Result<SuiTransactionBlockResponse> {
         let _object_locks = self
             .object_lock_manager
             .try_acquire_locks(reservation_id, &tx_data)
@@ -196,31 +223,49 @@ impl GasPool {
             })?;
         let sponsor = tx_data.gas_data().owner;
         let cur_time = std::time::Instant::now();
-        let sponsor_sig = retry_with_max_attempts!(
-            async {
-                self.signer
-                    .sign_transaction(&tx_data)
-                    .await
-                    .tap_err(|err| error!("Failed to sign transaction: {:?}", err))
-            },
-            3
-        )?;
-        let elapsed = cur_time.elapsed().as_millis();
-        self.metrics
-            .transaction_signing_latency_ms
-            .observe(elapsed as u64);
-        debug!(?reservation_id, "Transaction signed by sponsor");
 
-        let tx = Transaction::from_generic_sig_data(tx_data.clone(), vec![sponsor_sig, user_sig]);
+        // we already checked that it is allowed to use the same sender as sponsor
+        let sigs = if self.advanced_faucet_mode {
+            vec![user_sig]
+        } else {
+            let sponsor_sig = retry_with_max_attempts!(
+                async {
+                    self.signer
+                        .sign_transaction(&tx_data)
+                        .await
+                        .tap_err(|err| error!("Failed to sign transaction: {:?}", err))
+                },
+                3
+            )?;
+            let elapsed = cur_time.elapsed().as_millis();
+            self.metrics
+                .transaction_signing_latency_ms
+                .observe(elapsed as u64);
+            debug!(?reservation_id, "Transaction signed by sponsor");
+
+            vec![user_sig, sponsor_sig]
+        };
+        let tx = Transaction::from_generic_sig_data(tx_data.clone(), sigs);
         let cur_time = std::time::Instant::now();
-        let effects = self.sui_client.execute_transaction(tx, 3).await?;
+        let tx_response = self.sui_client.execute_transaction(tx, 3).await?;
+
+        let effects = tx_response
+            .effects
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Transaction execution failed: no effects returned"))?;
         debug!(?reservation_id, "Transaction executed");
         let elapsed = cur_time.elapsed().as_millis();
         self.metrics
             .transaction_execution_latency_ms
             .observe(elapsed as u64);
-        let net_gas_usage = effects.gas_cost_summary().net_gas_usage();
-        let new_daily_usage = self.gas_usage_cap.update_usage(net_gas_usage).await;
+
+        let net_coin_amount_usage: i64 = self.net_usage(
+            reservation_id,
+            &effects,
+            tx_response.balance_changes.as_ref(),
+        )?;
+
+        let new_daily_usage = self.gas_usage_cap.update_usage(net_coin_amount_usage).await;
         self.metrics
             .daily_gas_usage
             .with_label_values(&[&sponsor.to_string()])
@@ -232,7 +277,7 @@ impl GasPool {
             .collect();
         self.object_lock_manager
             .update_cache_post_execution(&tx_data, mutated_objects);
-        Ok(effects)
+        Ok(tx_response)
     }
 
     async fn get_total_gas_coin_balance(&self, gas_coins: Vec<ObjectID>) -> u64 {
@@ -244,7 +289,51 @@ impl GasPool {
             .sum()
     }
 
-    fn check_transaction_validity(tx_data: &TransactionData) -> anyhow::Result<()> {
+    /// Calculate the net gas usage based on the effects in the normal mode, and using balance
+    /// changes if advanced faucet mode is enabled. For the latter, we need to use balance changes
+    /// as we're using the gas coins to transfer SUI, rather than just pay for gas.
+    fn net_usage(
+        &self,
+        reservation_id: ReservationID,
+        effects: &SuiTransactionBlockEffects,
+        balance_changes: Option<&Vec<BalanceChange>>,
+    ) -> anyhow::Result<i64> {
+        let net_usage = if self.advanced_faucet_mode {
+            // we need to actually use balance changes to calculate how much SUI was used, because
+            // we're using the gas coins to transfer SUI.
+            let Some(net_gas_usage) = balance_changes.map(|balance| {
+                balance
+                    .into_iter()
+                    .filter_map(|c| (c.owner == effects.gas_object().owner).then_some(c.amount))
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .sum::<i128>()
+                    .abs()
+            }) else {
+                error!(
+                    ?reservation_id,
+                    "No balance changes found when trying to calculate net SUI usage"
+                );
+                bail!("No balance changes found")
+            };
+
+            net_gas_usage.try_into().map_err(|_| {
+                error!(
+                    ?reservation_id,
+                    "Failed to convert balance changes sum to i64 when advanced faucet mode is enabled"
+                );
+                anyhow::anyhow!(
+                    "Failed to convert balance changes sum to i64 when advanced faucet mode is enabled"
+                )
+            })?
+        } else {
+            effects.gas_cost_summary().net_gas_usage()
+        };
+
+        Ok(net_usage)
+    }
+
+    fn check_transaction_validity(&self, tx_data: &TransactionData) -> anyhow::Result<()> {
         let mut all_args = vec![];
         for command in tx_data.kind().iter_commands() {
             match command {
@@ -268,12 +357,29 @@ impl GasPool {
                 Command::Upgrade(_, _, _, _) => {}
             };
         }
-        let uses_gas = all_args
-            .into_iter()
-            .any(|arg| matches!(*arg, Argument::GasCoin));
-        if uses_gas {
-            bail!("Gas coin can only be used to pay gas")
-        };
+
+        let sender = tx_data.sender();
+        let sponsor = tx_data.gas_data().owner;
+        // ensure that the sponsor and sender are the same if `advanced_faucet_mode` is set to true
+        // and that the signer is the same as the sender.
+        // SAFETY: as signers is a NonEmpty type, calling first() is fine and should always
+        // retrieve the first element.
+        if self.advanced_faucet_mode && (sponsor != sender || *tx_data.signers().first() != sender)
+        {
+            bail!("Expected that the transaction signer is the same as the sender");
+        }
+
+        // When advanced-faucet-mode is enabled, we allow the use of gas coins in the transaction
+        if !self.advanced_faucet_mode {
+            let uses_gas = all_args
+                .into_iter()
+                .any(|arg| matches!(*arg, Argument::GasCoin));
+
+            if uses_gas {
+                bail!("Gas coin can only be used to pay gas")
+            };
+        }
+
         Ok(())
     }
 
@@ -359,6 +465,7 @@ impl GasPoolContainer {
         sui_client: SuiClient,
         gas_usage_daily_cap: u64,
         metrics: Arc<GasPoolCoreMetrics>,
+        advanced_faucet_mode: bool,
     ) -> Self {
         let inner = GasPool::new(
             signer,
@@ -366,6 +473,7 @@ impl GasPoolContainer {
             sui_client,
             metrics,
             Arc::new(GasUsageCap::new(gas_usage_daily_cap)),
+            advanced_faucet_mode,
         )
         .await;
         let (cancel_sender, cancel_receiver) = tokio::sync::oneshot::channel();

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -14,10 +14,16 @@ mod tests {
     use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
     use sui_types::gas_coin::MIST_PER_SUI;
 
+    const TEST_ADVANCED_FAUCET_MODE: bool = false;
+
     #[tokio::test]
     async fn test_basic_rpc_flow() {
-        let (test_cluster, _container, server) =
-            start_rpc_server_for_testing(vec![MIST_PER_SUI; 10], MIST_PER_SUI).await;
+        let (test_cluster, _container, server) = start_rpc_server_for_testing(
+            vec![MIST_PER_SUI; 10],
+            MIST_PER_SUI,
+            TEST_ADVANCED_FAUCET_MODE,
+        )
+        .await;
         let client = server.get_local_client();
         client.health().await.unwrap();
 
@@ -38,8 +44,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_auth() {
-        let (_test_cluster, _container, server) =
-            start_rpc_server_for_testing(vec![MIST_PER_SUI; 10], MIST_PER_SUI).await;
+        let (_test_cluster, _container, server) = start_rpc_server_for_testing(
+            vec![MIST_PER_SUI; 10],
+            MIST_PER_SUI,
+            TEST_ADVANCED_FAUCET_MODE,
+        )
+        .await;
 
         let client = server.get_local_client();
         client.health().await.unwrap();
@@ -54,8 +64,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_debug_health_check() {
-        let (_test_cluster, _container, server) =
-            start_rpc_server_for_testing(vec![MIST_PER_SUI; 10], MIST_PER_SUI).await;
+        let (_test_cluster, _container, server) = start_rpc_server_for_testing(
+            vec![MIST_PER_SUI; 10],
+            MIST_PER_SUI,
+            TEST_ADVANCED_FAUCET_MODE,
+        )
+        .await;
 
         let client = server.get_local_client();
         client.debug_health_check().await.unwrap();

--- a/src/storage/redis/lua_scripts/init_coin_stats_at_startup.lua
+++ b/src/storage/redis/lua_scripts/init_coin_stats_at_startup.lua
@@ -19,6 +19,8 @@ end
 
 local t_available_coin_total_balance = sponsor_address .. ':available_coin_total_balance'
 local total_balance = redis.call('GET', t_available_coin_total_balance)
+redis.log(redis.LOG_WARNING, "total_balance before if: " .. tostring(total_balance))
+
 if not total_balance then
     local elements = redis.call('LRANGE', t_available_gas_coins, 0, -1)
     total_balance = 0
@@ -26,7 +28,10 @@ if not total_balance then
         -- Each coin is just a string, using "," to separate fields. The first is balance.
         local idx, _ = string.find(coin, ',', 1)
         local balance = string.sub(coin, 1, idx - 1)
-        total_balance = total_balance + tonumber(balance)
+        redis.log(redis.LOG_WARNING, "parsed balance: " .. balance)
+        -- Handle scientific notation by converting to a regular number
+        total_balance = total_balance + math.tointeger(balance)
+        redis.log(redis.LOG_WARNING, "updated total_balance: " .. total_balance)
     end
     redis.call('SET', t_available_coin_total_balance, total_balance)
 end

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -14,15 +14,18 @@ use std::sync::Arc;
 use sui_config::local_ip_utils::{get_available_port, localhost_for_testing};
 use sui_swarm_config::genesis_config::AccountConfig;
 use sui_types::base_types::{ObjectRef, SuiAddress};
-use sui_types::crypto::get_account_key_pair;
+use sui_types::crypto::{get_account_key_pair, KeypairTraits, SuiKeyPair};
 use sui_types::gas_coin::MIST_PER_SUI;
 use sui_types::signature::GenericSignature;
 use sui_types::transaction::{TransactionData, TransactionDataAPI};
 use test_cluster::{TestCluster, TestClusterBuilder};
 use tracing::debug;
 
-pub async fn start_sui_cluster(init_gas_amounts: Vec<u64>) -> (TestCluster, Arc<dyn TxSigner>) {
+pub async fn start_sui_cluster(
+    init_gas_amounts: Vec<u64>,
+) -> (TestCluster, Arc<dyn TxSigner>, SuiKeyPair) {
     let (sponsor, keypair) = get_account_key_pair();
+    let pk = SuiKeyPair::Ed25519(keypair.copy());
     let cluster = TestClusterBuilder::new()
         .with_accounts(vec![
             AccountConfig {
@@ -37,15 +40,16 @@ pub async fn start_sui_cluster(init_gas_amounts: Vec<u64>) -> (TestCluster, Arc<
         ])
         .build()
         .await;
-    (cluster, TestTxSigner::new(keypair.into()))
+    (cluster, TestTxSigner::new(keypair.into()), pk)
 }
 
 pub async fn start_gas_station(
     init_gas_amounts: Vec<u64>,
     target_init_coin_balance: u64,
+    advanced_faucet_mode: bool,
 ) -> (TestCluster, GasPoolContainer) {
     debug!("Starting Sui cluster..");
-    let (test_cluster, signer) = start_sui_cluster(init_gas_amounts).await;
+    let (test_cluster, signer, _) = start_sui_cluster(init_gas_amounts).await;
     let fullnode_url = test_cluster.fullnode_handle.rpc_url.clone();
     let sponsor_address = signer.get_address();
     debug!("Starting storage. Sponsor address: {:?}", sponsor_address);
@@ -67,6 +71,7 @@ pub async fn start_gas_station(
         sui_client,
         DEFAULT_DAILY_GAS_USAGE_CAP,
         GasPoolCoreMetrics::new_for_testing(),
+        advanced_faucet_mode,
     )
     .await;
     (test_cluster, station)
@@ -75,8 +80,10 @@ pub async fn start_gas_station(
 pub async fn start_rpc_server_for_testing(
     init_gas_amounts: Vec<u64>,
     target_init_balance: u64,
+    advanced_faucet_mode: bool,
 ) -> (TestCluster, GasPoolContainer, GasPoolServer) {
-    let (test_cluster, container) = start_gas_station(init_gas_amounts, target_init_balance).await;
+    let (test_cluster, container) =
+        start_gas_station(init_gas_amounts, target_init_balance, advanced_faucet_mode).await;
     let localhost = localhost_for_testing();
     std::env::set_var(AUTH_ENV_NAME, "some secret");
     let server = GasPoolServer::new(
@@ -113,6 +120,101 @@ pub async fn create_test_transaction(
     // TODO: Add proper sponsored transaction support to test tx builder.
     tx_data.gas_data_mut().payment = gas_coins;
     tx_data.gas_data_mut().owner = sponsor;
+    let user_sig = test_cluster
+        .sign_transaction(&tx_data)
+        .into_data()
+        .tx_signatures_mut_for_testing()
+        .pop()
+        .unwrap();
+    (tx_data, user_sig)
+}
+
+pub async fn start_gas_station_with_cluster(
+    test_cluster: &mut TestCluster,
+    signer: Arc<dyn TxSigner>,
+    target_init_coin_balance: u64,
+    advanced_faucet_mode: bool,
+) -> (&mut TestCluster, GasPoolContainer) {
+    debug!("Starting Sui cluster..");
+    let fullnode_url = test_cluster.fullnode_handle.rpc_url.clone();
+    let sponsor_address = signer.get_address();
+    debug!("Starting storage. Sponsor address: {:?}", sponsor_address);
+    let storage = connect_storage_for_testing(sponsor_address).await;
+    let sui_client = SuiClient::new(&fullnode_url, None).await;
+    GasPoolInitializer::start(
+        sui_client.clone(),
+        storage.clone(),
+        CoinInitConfig {
+            target_init_balance: target_init_coin_balance,
+            ..Default::default()
+        },
+        signer.clone(),
+    )
+    .await;
+    let station = GasPoolContainer::new(
+        signer,
+        storage,
+        sui_client,
+        DEFAULT_DAILY_GAS_USAGE_CAP,
+        GasPoolCoreMetrics::new_for_testing(),
+        advanced_faucet_mode,
+    )
+    .await;
+    (test_cluster, station)
+}
+
+pub async fn create_test_transaction_with_same_sender_as_sponsor(
+    test_cluster: &mut TestCluster,
+    sponsor: SuiAddress,
+    keypair: SuiKeyPair,
+    gas_coins: Vec<ObjectRef>,
+) -> (TransactionData, GenericSignature) {
+    let user = sponsor.clone();
+    test_cluster
+        .wallet_mut()
+        .add_account(Some("sponsor".to_string()), keypair);
+    let object = test_cluster
+        .wallet
+        .get_one_gas_object_owned_by_address(user)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut tx_data = test_cluster
+        .test_transaction_builder_with_gas_object(user, gas_coins[0])
+        .await
+        .transfer(object, user)
+        .build();
+    // TODO: Add proper sponsored transaction support to test tx builder.
+    tx_data.gas_data_mut().payment = gas_coins;
+    tx_data.gas_data_mut().owner = sponsor;
+    let user_sig = test_cluster
+        .sign_transaction(&tx_data)
+        .into_data()
+        .tx_signatures_mut_for_testing()
+        .pop()
+        .unwrap();
+    (tx_data, user_sig)
+}
+
+pub async fn create_pay_sui_transaction_same_sender_as_sponsor(
+    test_cluster: &mut TestCluster,
+    sponsor: SuiAddress,
+    keypair: SuiKeyPair,
+    gas_coins: Vec<ObjectRef>,
+) -> (TransactionData, GenericSignature) {
+    test_cluster.wallet_mut().add_account(None, keypair);
+
+    let recipient = get_account_key_pair();
+    let tx_data = TransactionData::new_pay_sui(
+        sponsor,
+        gas_coins[1..].to_vec(),
+        vec![recipient.0],
+        vec![1_000_000_000],
+        gas_coins[0],
+        10000000,
+        test_cluster.get_reference_gas_price().await,
+    )
+    .unwrap();
     let user_sig = test_cluster
         .sign_transaction(&tx_data)
         .into_data()


### PR DESCRIPTION
This PR adds a new feature to allow to set up the gas pool as a faucet backend. 

In this `advanced-faucet-mode`, it needs to use the gas coins for txs, and the gas sponsor and transaction sender are the same.