### PR TITLE
support multiple bearer secrets for key rotation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,12 @@ pub mod types;
 
 pub const AUTH_ENV_NAME: &str = "GAS_STATION_AUTH";
 
+pub fn read_auth_env() -> String {
+    std::env::var(AUTH_ENV_NAME)
+        .ok()
+        .unwrap_or_else(|| panic!("{} environment variable must be specified", AUTH_ENV_NAME))
+}
+
 pub fn read_auth_envs() -> Vec<String> {
     let raw = std::env::var(AUTH_ENV_NAME)
         .ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,10 @@ pub fn read_auth_env() -> String {
         .parse::<String>()
         .unwrap()
 }
+
+pub fn read_auth_envs() -> Vec<String> {
+    let raw = std::env::var(AUTH_ENV_NAME)
+        .ok()
+        .unwrap_or_else(|| panic!("{} environment variable must be specified", AUTH_ENV_NAME));
+    raw.split(',').map(|s| s.trim().to_string()).collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,6 @@ pub mod types;
 
 pub const AUTH_ENV_NAME: &str = "GAS_STATION_AUTH";
 
-pub fn read_auth_env() -> String {
-    std::env::var(AUTH_ENV_NAME)
-        .ok()
-        .unwrap_or_else(|| panic!("{} environment variable must be specified", AUTH_ENV_NAME))
-}
-
 pub fn read_auth_envs() -> Vec<String> {
     let raw = std::env::var(AUTH_ENV_NAME)
         .ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,6 @@ pub mod types;
 
 pub const AUTH_ENV_NAME: &str = "GAS_STATION_AUTH";
 
-pub fn read_auth_env() -> String {
-    std::env::var(AUTH_ENV_NAME)
-        .ok()
-        .unwrap_or_else(|| panic!("{} environment variable must be specified", AUTH_ENV_NAME))
-        .parse::<String>()
-        .unwrap()
-}
-
 pub fn read_auth_envs() -> Vec<String> {
     let raw = std::env::var(AUTH_ENV_NAME)
         .ok()

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::read_auth_env;
+use crate::read_auth_envs;
 use crate::rpc::rpc_types::{
     ExecuteTxRequest, ExecuteTxResponse, ReserveGasRequest, ReserveGasResponse,
 };
@@ -60,7 +60,7 @@ impl GasPoolRpcClient {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
-            format!("Bearer {}", read_auth_env()).parse().unwrap(),
+            format!("Bearer {}", read_auth_envs()[0]).parse().unwrap(),
         );
         let response = self
             .client
@@ -91,7 +91,7 @@ impl GasPoolRpcClient {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
-            format!("Bearer {}", read_auth_env()).parse().unwrap(),
+            format!("Bearer {}", read_auth_envs()[0]).parse().unwrap(),
         );
         let response = self
             .client
@@ -134,7 +134,7 @@ impl GasPoolRpcClient {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
-            format!("Bearer {}", read_auth_env()).parse().unwrap(),
+            format!("Bearer {}", read_auth_envs()[0]).parse().unwrap(),
         );
         let request = ExecuteTxRequest {
             reservation_id,

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::read_auth_envs;
+use crate::read_auth_env;
 use crate::rpc::rpc_types::{
     ExecuteTxRequest, ExecuteTxResponse, ReserveGasRequest, ReserveGasResponse,
 };
@@ -60,7 +60,7 @@ impl GasPoolRpcClient {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
-            format!("Bearer {}", read_auth_envs()[0]).parse().unwrap(),
+            format!("Bearer {}", read_auth_env()).parse().unwrap(),
         );
         let response = self
             .client
@@ -91,7 +91,7 @@ impl GasPoolRpcClient {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
-            format!("Bearer {}", read_auth_envs()[0]).parse().unwrap(),
+            format!("Bearer {}", read_auth_env()).parse().unwrap(),
         );
         let response = self
             .client
@@ -134,7 +134,7 @@ impl GasPoolRpcClient {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
-            format!("Bearer {}", read_auth_envs()[0]).parse().unwrap(),
+            format!("Bearer {}", read_auth_env()).parse().unwrap(),
         );
         let request = ExecuteTxRequest {
             reservation_id,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -11,7 +11,7 @@ pub use server::GasPoolServer;
 mod tests {
     use crate::AUTH_ENV_NAME;
     use crate::rpc::server::MAX_INPUT_OBJECTS;
-    use crate::test_env::{create_test_transaction, start_rpc_server_for_testing};
+    use crate::test_env::{create_test_transaction, start_gas_station, start_rpc_server_for_testing};
     use shared_crypto::intent::{Intent, IntentMessage};
     use sui_json_rpc_types::{SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponseOptions};
     use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
@@ -172,6 +172,48 @@ mod tests {
             std::env::set_var(AUTH_ENV_NAME, "b");
         }
 
+        assert!(client.reserve_gas(MIST_PER_SUI, 10).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_multiple_auth_secrets() {
+        use crate::config::DEFAULT_MAX_SUI_PER_REQUEST;
+        use crate::metrics::GasPoolRpcMetrics;
+        use crate::rpc::GasPoolServer;
+        use sui_config::local_ip_utils::{get_available_port, localhost_for_testing};
+
+        let (_test_cluster, _container) = start_gas_station(
+            vec![MIST_PER_SUI; 10],
+            MIST_PER_SUI,
+            TEST_ADVANCED_FAUCET_MODE,
+        )
+        .await
+        .unwrap();
+
+        let localhost = localhost_for_testing();
+        // Set multiple comma-separated secrets before starting the server.
+        unsafe { std::env::set_var(AUTH_ENV_NAME, "secret_a,secret_b") };
+        let server = GasPoolServer::new(
+            _container.get_gas_pool_arc(),
+            localhost.parse().unwrap(),
+            get_available_port(&localhost),
+            GasPoolRpcMetrics::new_for_testing(),
+            DEFAULT_MAX_SUI_PER_REQUEST,
+        )
+        .await;
+
+        let client = server.get_local_client();
+
+        // Client uses first secret — should work.
+        unsafe { std::env::set_var(AUTH_ENV_NAME, "secret_a") };
+        assert!(client.reserve_gas(MIST_PER_SUI, 10).await.is_ok());
+
+        // Client uses second secret — should also work.
+        unsafe { std::env::set_var(AUTH_ENV_NAME, "secret_b") };
+        assert!(client.reserve_gas(MIST_PER_SUI, 10).await.is_ok());
+
+        // Client uses invalid secret — should fail.
+        unsafe { std::env::set_var(AUTH_ENV_NAME, "wrong") };
         assert!(client.reserve_gas(MIST_PER_SUI, 10).await.is_err());
     }
 

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -4,7 +4,7 @@
 use crate::gas_pool::gas_pool_core::GasPool;
 use crate::metrics::GasPoolRpcMetrics;
 use crate::object_locks::get_imm_or_owned_non_gas_objects;
-use crate::read_auth_env;
+use crate::read_auth_envs;
 use crate::rpc::client::GasPoolRpcClient;
 use crate::rpc::rpc_types::{
     ExecuteTxRequest, ExecuteTxResponse, ReserveGasRequest, ReserveGasResponse,
@@ -85,7 +85,7 @@ impl GasPoolServer {
 #[derive(Clone)]
 struct ServerState {
     gas_station: Arc<GasPool>,
-    secret: Arc<String>,
+    secrets: Arc<Vec<String>>,
     metrics: Arc<GasPoolRpcMetrics>,
     max_sui_per_request: u64,
 }
@@ -96,10 +96,10 @@ impl ServerState {
         metrics: Arc<GasPoolRpcMetrics>,
         max_sui_per_request: u64,
     ) -> Self {
-        let secret = Arc::new(read_auth_env());
+        let secrets = Arc::new(read_auth_envs());
         Self {
             gas_station,
-            secret,
+            secrets,
             metrics,
             max_sui_per_request,
         }
@@ -121,7 +121,7 @@ async fn debug_health_check(
     Extension(server): Extension<ServerState>,
 ) -> String {
     info!("Received debug_health_check request");
-    if authorization.token() != server.secret.as_str() {
+    if !server.secrets.iter().any(|s| s == authorization.token()) {
         return "Unauthorized".to_string();
     }
     if let Err(err) = server.gas_station.debug_check_health().await {
@@ -136,7 +136,7 @@ async fn reserve_gas(
     Json(payload): Json<ReserveGasRequest>,
 ) -> impl IntoResponse {
     server.metrics.num_reserve_gas_requests.inc();
-    if authorization.token() != server.secret.as_str() {
+    if !server.secrets.iter().any(|s| s == authorization.token()) {
         return (
             StatusCode::UNAUTHORIZED,
             Json(ReserveGasResponse::new_err(anyhow::anyhow!(
@@ -224,7 +224,7 @@ async fn execute_tx(
     Json(payload): Json<ExecuteTxRequest>,
 ) -> impl IntoResponse {
     server.metrics.num_execute_tx_requests.inc();
-    if authorization.token() != server.secret.as_ref() {
+    if !server.secrets.iter().any(|s| s == authorization.token()) {
         return (
             StatusCode::UNAUTHORIZED,
             Json(ExecuteTxResponse::new_err(anyhow::anyhow!(

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -121,7 +121,7 @@ async fn debug_health_check(
     Extension(server): Extension<ServerState>,
 ) -> String {
     info!("Received debug_health_check request");
-    if !server.secrets.iter().any(|s| s == authorization.token()) {
+    if !server.secrets.contains(&authorization.token().to_string()) {
         return "Unauthorized".to_string();
     }
     if let Err(err) = server.gas_station.debug_check_health().await {
@@ -136,7 +136,7 @@ async fn reserve_gas(
     Json(payload): Json<ReserveGasRequest>,
 ) -> impl IntoResponse {
     server.metrics.num_reserve_gas_requests.inc();
-    if !server.secrets.iter().any(|s| s == authorization.token()) {
+    if !server.secrets.contains(&authorization.token().to_string()) {
         return (
             StatusCode::UNAUTHORIZED,
             Json(ReserveGasResponse::new_err(anyhow::anyhow!(
@@ -224,7 +224,7 @@ async fn execute_tx(
     Json(payload): Json<ExecuteTxRequest>,
 ) -> impl IntoResponse {
     server.metrics.num_execute_tx_requests.inc();
-    if !server.secrets.iter().any(|s| s == authorization.token()) {
+    if !server.secrets.contains(&authorization.token().to_string()) {
         return (
             StatusCode::UNAUTHORIZED,
             Json(ExecuteTxResponse::new_err(anyhow::anyhow!(


### PR DESCRIPTION
## Summary
- `GAS_STATION_AUTH` now accepts comma-separated secrets (e.g. `old_key,new_key`)
- All provided secrets are valid simultaneously, enabling zero-downtime key rotation
- Follows the same pattern as [enoki-salt-server](https://github.com/MystenLabs/enoki-salt-server)

https://github.com/MystenLabs/sui-operations/blob/e7f637f10aebc2299db6a360694f376fe561e732/pulumi/services/gas-station/service.py#L123

## Changes
- Added `read_auth_envs()` in `src/lib.rs` that splits the env var on commas
- Changed `ServerState.secret` from a single `String` to `Vec<String>`
- Updated auth checks in all 3 protected endpoints to accept any valid secret

## No infra changes needed
The Pulumi `service.py` passes `bearer_secret` through as-is to `GAS_STATION_AUTH` — just set the value to `"old_key,new_key"` during rotation.

## Test plan
- [x] `cargo check` passes
- [x] Existing `test_invalid_auth` test still passes
- [ ] Manual verification with comma-separated secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)